### PR TITLE
Name fix for gameofthrones continuous palettes.

### DIFF
--- a/data-raw/palettes_c_names.R
+++ b/data-raw/palettes_c_names.R
@@ -61,7 +61,7 @@ harrypotter_df <- tibble(package = "harrypotter",
                          palette = unique(harrypotter::hp.map$option),
                          type = "sequential")
 
-gameofthrones_df <- tibble(package = "harrypotter",
+gameofthrones_df <- tibble(package = "gameofthrones",
                            palette = unique(gameofthrones::got.map$house),
                            type = "sequential")
 


### PR DESCRIPTION
I replaced the duplicated `harrypotter` string that was listed under the `gameofthrones` palettes.