### PR TITLE
Update tests for incoming ggplot2 version

### DIFF
--- a/tests/testthat/test-ggplot2_scales_binned.R
+++ b/tests/testthat/test-ggplot2_scales_binned.R
@@ -18,9 +18,15 @@ test_that("scale_*_paletteer_binned correctly assigns colors", {
     ggplot2::geom_raster() +
     scale_fill_paletteer_binned("scico::berlin")
 
-  expect_equal(ggplot2::layer_data(p1)$colour, c("#65A6E1", "#183E4F", "#CC7D72"))
-  expect_equal(ggplot2::layer_data(p2)$colour, c("#65A6E1", "#183E4F", "#CC7D72"))
-  expect_equal(ggplot2::layer_data(p3)$fill, c("#65A6E1", "#183E4F", "#CC7D72"))
+  colours <- if (utils::packageVersion("ggplot2") < "3.5.0") {
+    c("#65A6E1", "#183E4F", "#CC7D72")
+  } else {
+    c("#519FD2", "#13313E", "#BB6C60")
+  }
+
+  expect_equal(ggplot2::layer_data(p1)$colour, colours)
+  expect_equal(ggplot2::layer_data(p2)$colour, colours)
+  expect_equal(ggplot2::layer_data(p3)$fill, colours)
 })
 
 test_that("scale_*_paletteer_binned correctly used direction", {
@@ -49,12 +55,25 @@ test_that("scale_*_paletteer_binned correctly used direction", {
     ggplot2::geom_raster() +
     scale_fill_paletteer_binned("scico::berlin", direction = -1)
 
-  expect_equal(ggplot2::layer_data(p1)$colour, c("#65A6E1", "#183E4F", "#CC7D72"))
-  expect_equal(ggplot2::layer_data(p2)$colour, c("#65A6E1", "#183E4F", "#CC7D72"))
-  expect_equal(ggplot2::layer_data(p3)$fill, c("#65A6E1", "#183E4F", "#CC7D72"))
-  expect_equal(ggplot2::layer_data(p4)$colour, c("#CC7D72", "#4B1501", "#65A6E1"))
-  expect_equal(ggplot2::layer_data(p5)$colour, c("#CC7D72", "#4B1501", "#65A6E1"))
-  expect_equal(ggplot2::layer_data(p6)$fill, c("#CC7D72", "#4B1501", "#65A6E1"))
+  colours <- if (utils::packageVersion("ggplot2") < "3.5.0") {
+    c("#65A6E1", "#183E4F", "#CC7D72")
+  } else {
+    c("#519FD2", "#13313E", "#BB6C60")
+  }
+
+  expect_equal(ggplot2::layer_data(p1)$colour, colours)
+  expect_equal(ggplot2::layer_data(p2)$colour, colours)
+  expect_equal(ggplot2::layer_data(p3)$fill, colours)
+
+  colours <- if (utils::packageVersion("ggplot2") < "3.5.0") {
+    c("#CC7D72", "#4B1501", "#65A6E1")
+  } else {
+    c("#BB6C60", "#3F1200", "#519FD2")
+  }
+
+  expect_equal(ggplot2::layer_data(p4)$colour, colours)
+  expect_equal(ggplot2::layer_data(p5)$colour, colours)
+  expect_equal(ggplot2::layer_data(p6)$fill, colours)
 })
 
 test_that("scale_*_paletteer_binned works with quoted palettes", {

--- a/tests/testthat/test-ggplot2_scales_discrete.R
+++ b/tests/testthat/test-ggplot2_scales_discrete.R
@@ -78,31 +78,27 @@ test_that("scale_*_paletteer_d correctly used direction", {
 
 test_that("scale_*_paletteer_d works with quoted palettes", {
   testthat::skip_if_not_installed("ggplot2")
-  expect_equal(
-    ggplot2::ggplot(df, ggplot2::aes(x, y, colour = color)) +
-      ggplot2::geom_point() +
-      scale_colour_paletteer_d(`"nord::lumina"`),
-    ggplot2::ggplot(df, ggplot2::aes(x, y, colour = color)) +
-      ggplot2::geom_point() +
-      scale_colour_paletteer_d("nord::lumina")
+
+  expect_equal_scales <- function(x, y, ...) {
+    x <- as.list(x)
+    y <- as.list(y)
+    x$call <- y$call <- NULL # the calls are different between quoted/unquoted
+    expect_equal(x, y, ...)
+  }
+
+  expect_equal_scales(
+    scale_colour_paletteer_d(`"nord::lumina"`),
+    scale_colour_paletteer_d("nord::lumina")
   )
 
-  expect_equal(
-    ggplot2::ggplot(df, ggplot2::aes(x, y, color = color)) +
-      ggplot2::geom_point() +
-      scale_color_paletteer_d(palette = `"nord::lumina"`),
-    ggplot2::ggplot(df, ggplot2::aes(x, y, color = color)) +
-      ggplot2::geom_point() +
-      scale_color_paletteer_d("nord::lumina")
+  expect_equal_scales(
+    scale_color_paletteer_d(palette = `"nord::lumina"`),
+    scale_color_paletteer_d("nord::lumina")
   )
 
-  expect_equal(
-    ggplot2::ggplot(df, ggplot2::aes(x, y, fill = color)) +
-      ggplot2::geom_raster() +
-      scale_fill_paletteer_d(`"nord::lumina"`),
-    ggplot2::ggplot(df, ggplot2::aes(x, y, fill = color)) +
-      ggplot2::geom_raster() +
-      scale_fill_paletteer_d("nord::lumina")
+  expect_equal_scales(
+    scale_fill_paletteer_d(`"nord::lumina"`),
+    scale_fill_paletteer_d("nord::lumina")
   )
 })
 


### PR DESCRIPTION
Hi Emil,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break paletteer.

This PR updates tests to be compatible with both the old and new version of ggplot2.
Due to changes to the binned scale break calculation, the expected colours have changed slightly between versions of ggplot2.
Also we've changed the `call` field of scales to give more informative error messages about scales. However, this means that testing that scales are *effectively* equal needs a tweak to ignore the `call` field.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help paletteer get out a fix if necessary.